### PR TITLE
Add dtype argument to init of modules

### DIFF
--- a/tests/test_spherical_expansions.py
+++ b/tests/test_spherical_expansions.py
@@ -16,22 +16,27 @@ class TestEthanol1SphericalExpansion:
     Tests on the ethanol1 dataset
     """
     device = "cpu"
+    dtype = torch.float32
     frames = ase.io.read('datasets/rmd17/ethanol1.extxyz', ':1')
     all_species = list(np.unique([frame.numbers for frame in frames]))
     with open("tests/data/expansion_coeffs-ethanol1_0-hypers.json", "r") as f:
         hypers = json.load(f)
 
-    transformers = [TransformerNeighborList(cutoff=hypers["cutoff radius"])]
+    transformers = [TransformerNeighborList(cutoff=hypers["cutoff radius"],
+        dtype=dtype, device=device)]
+
     dataset = InMemoryDataset(frames, transformers)
     loader = DataLoader(dataset, batch_size=1, collate_fn=collate_nl)
     batch = next(iter(loader))
 
     def test_vector_expansion_coeffs(self):
         tm_ref = metatensor.torch.load("tests/data/vector_expansion_coeffs-ethanol1_0-data.npz")
+        tm_ref = metatensor.torch.to(tm_ref, device=self.device, dtype=self.dtype)
         # we need to sort both computed and reference pair expansion coeffs,
         # because ase.neighborlist can get different neighborlist order for some reasons
         tm_ref = sort_tm(tm_ref)
-        vector_expansion = VectorExpansion(self.hypers, self.all_species, device=self.device)
+        vector_expansion = VectorExpansion(self.hypers, self.all_species,
+                device=self.device, dtype=self.dtype)
         with torch.no_grad():
             tm = sort_tm(vector_expansion.forward(**self.batch))
         # Default types are float32 so we cannot get higher accuracy than 1e-7.
@@ -41,7 +46,9 @@ class TestEthanol1SphericalExpansion:
 
     def test_spherical_expansion_coeffs(self):
         tm_ref = metatensor.torch.load("tests/data/spherical_expansion_coeffs-ethanol1_0-data.npz")
-        spherical_expansion_calculator = SphericalExpansion(self.hypers, self.all_species, device=self.device)
+        tm_ref = metatensor.torch.to(tm_ref, device=self.device, dtype=self.dtype)
+        spherical_expansion_calculator = SphericalExpansion(self.hypers,
+                self.all_species, device=self.device, dtype=self.dtype)
         with torch.no_grad():
             tm = spherical_expansion_calculator.forward(**self.batch)
         # Default types are float32 so we cannot get higher accuracy than 1e-7.
@@ -53,8 +60,10 @@ class TestEthanol1SphericalExpansion:
         with open("tests/data/expansion_coeffs-ethanol1_0-alchemical-hypers.json", "r") as f:
             hypers = json.load(f)
         tm_ref = metatensor.torch.load("tests/data/spherical_expansion_coeffs-ethanol1_0-alchemical-seed0-data.npz")
+        tm_ref = metatensor.torch.to(tm_ref, device=self.device, dtype=self.dtype)
         torch.manual_seed(0)
-        spherical_expansion_calculator = SphericalExpansion(hypers, self.all_species, device=self.device)
+        spherical_expansion_calculator = SphericalExpansion(hypers, self.all_species,
+                device=self.device, dtype=self.dtype)
         # Because setting seed seems not be enough to get the same initial combination matrix
         # as in the reference values, we set the combination matrix manually
         with torch.no_grad():
@@ -62,7 +71,8 @@ class TestEthanol1SphericalExpansion:
             # https://discuss.pytorch.org/t/initialize-nn-linear-with-specific-weights/29005/4
             spherical_expansion_calculator.vector_expansion_calculator.radial_basis_calculator.combination_matrix.weight.copy_(torch.tensor(
                     [[-0.00432252,  0.30971584, -0.47518533],
-                     [-0.4248946 , -0.22236897,  0.15482073]], dtype=torch.float32))
+                     [-0.4248946 , -0.22236897,  0.15482073]],
+                    device=self.device, dtype=self.dtype))
 
         with torch.no_grad():
             tm = spherical_expansion_calculator.forward(**self.batch)
@@ -76,27 +86,33 @@ class TestArtificialSphericalExpansion:
     Tests on the artificial dataset
     """
     device = "cpu"
+    dtype = torch.float32
     frames = ase.io.read('tests/datasets/artificial.extxyz', ':')
     all_species = list(np.unique(np.hstack([frame.numbers for frame in frames])))
     with open("tests/data/expansion_coeffs-artificial-hypers.json", "r") as f:
         hypers = json.load(f)
 
-    transformers = [TransformerNeighborList(cutoff=hypers["cutoff radius"])]
+    transformers = [TransformerNeighborList(cutoff=hypers["cutoff radius"],
+        dtype=dtype, device=device)]
     dataset = InMemoryDataset(frames, transformers)
     loader = DataLoader(dataset, batch_size=len(frames), collate_fn=collate_nl)
     batch = next(iter(loader))
 
     def test_vector_expansion_coeffs(self):
         tm_ref = metatensor.torch.load("tests/data/vector_expansion_coeffs-artificial-data.npz")
+        tm_ref = metatensor.torch.to(tm_ref, device=self.device, dtype=self.dtype)
         tm_ref = sort_tm(tm_ref)
-        vector_expansion = VectorExpansion(self.hypers, self.all_species, device=self.device)
+        vector_expansion = VectorExpansion(self.hypers, self.all_species,
+                device=self.device, dtype=self.dtype)
         with torch.no_grad():
             tm = sort_tm(vector_expansion.forward(**self.batch))
         assert metatensor.torch.allclose(tm_ref, tm, atol=1e-5, rtol=1e-5)
 
     def test_spherical_expansion_coeffs(self):
         tm_ref = metatensor.torch.load("tests/data/spherical_expansion_coeffs-artificial-data.npz")
-        spherical_expansion_calculator = SphericalExpansion(self.hypers, self.all_species, device=self.device)
+        tm_ref = metatensor.torch.to(tm_ref, device=self.device, dtype=self.dtype)
+        spherical_expansion_calculator = SphericalExpansion(self.hypers,
+                self.all_species, device=self.device, dtype=self.dtype)
         with torch.no_grad():
             tm = spherical_expansion_calculator.forward(**self.batch)
         # The absolute accuracy is a bit smaller than in the ethanol case
@@ -107,13 +123,15 @@ class TestArtificialSphericalExpansion:
         with open("tests/data/expansion_coeffs-artificial-alchemical-hypers.json", "r") as f:
             hypers = json.load(f)
         tm_ref = metatensor.torch.load("tests/data/spherical_expansion_coeffs-artificial-alchemical-seed0-data.npz")
-        spherical_expansion_calculator = SphericalExpansion(hypers, self.all_species, device=self.device)
+        tm_ref = metatensor.torch.to(tm_ref, device=self.device, dtype=self.dtype)
+        spherical_expansion_calculator = SphericalExpansion(hypers, self.all_species,
+                device=self.device, dtype=self.dtype)
         with torch.no_grad():
             spherical_expansion_calculator.vector_expansion_calculator.radial_basis_calculator.combination_matrix.weight.copy_(
                 torch.tensor(
                     [[-0.00432252,  0.30971584, -0.47518533],
                      [-0.4248946 , -0.22236897,  0.15482073]],
-                    dtype=torch.float32
+                    device=self.device, dtype=self.dtype
                 )
             )
         with torch.no_grad():

--- a/torch_spex/le.py
+++ b/torch_spex/le.py
@@ -6,6 +6,8 @@ from scipy.special import spherical_jn as j_l
 from scipy import integrate
 from .splines import generate_splines
 import copy
+import torch
+from typing import Optional
 
 
 def Jn(r, n):
@@ -24,7 +26,7 @@ def Jn_zeros(n, nt):
     return zeros_j
 
 
-def get_le_spliner(E_max, r_cut, normalize, device):
+def get_le_spliner(E_max, r_cut, normalize, device: Optional[torch.device]=None, dtype: Optional[torch.dtype]=None):
 
     l_big = 50
     n_big = 50
@@ -104,6 +106,7 @@ def get_le_spliner(E_max, r_cut, normalize, device):
         np.sum(n_max_l),
         r_cut,
         requested_accuracy=1e-6,
-        device=device
+        device=device,
+        dtype=dtype
     )
 

--- a/torch_spex/physical_le.py
+++ b/torch_spex/physical_le.py
@@ -9,6 +9,8 @@ from scipy.special import spherical_in as i_l
 from scipy.integrate import quadrature
 from .le import Jn_zeros
 from .splines import generate_splines
+from typing import Optional
+import torch
 
 
 def get_laplacian_eigenvalues(n_big, l_big, cost_trade_off):
@@ -91,7 +93,9 @@ def integrate_H(l, m, n, alpha, z_nl, precomputed_N_nl):
     )[0]
 
 
-def get_physical_le_spliner(E_max, r_cut, r0, normalize, cost_trade_off, device):
+def get_physical_le_spliner(E_max, r_cut, r0, normalize, cost_trade_off,
+    device: Optional[torch.device]=None,
+    dtype: Optional[torch.dtype]=None):
 
     rs = False
     rnn = 0.0
@@ -247,5 +251,6 @@ def get_physical_le_spliner(E_max, r_cut, r0, normalize, cost_trade_off, device)
         np.sum(n_max_l),
         r_cut,
         requested_accuracy=1e-6,
-        device=device
+        device=device,
+        dtype=dtype
     )

--- a/torch_spex/spherical_expansions.py
+++ b/torch_spex/spherical_expansions.py
@@ -6,7 +6,7 @@ from metatensor.torch import TensorMap, Labels, TensorBlock
 import sphericart.torch
 
 from .radial_basis import RadialBasis
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 
 class SphericalExpansion(torch.nn.Module):
@@ -77,7 +77,9 @@ class SphericalExpansion(torch.nn.Module):
 
     """
 
-    def __init__(self, hypers: Dict, all_species: List[int], device: str = "cpu") -> None:
+    def __init__(self, hypers: Dict, all_species: List[int],
+            device: Optional[torch.device] = None,
+            dtype: Optional[torch.device] = None) -> None:
         super().__init__()
 
         self.hypers = hypers
@@ -90,7 +92,8 @@ class SphericalExpansion(torch.nn.Module):
             self.normalization_factor = 1.0  # dummy for torchscript
             self.normalization_factor_0 = 1.0  # dummy for torchscript
         self.all_species = all_species
-        self.vector_expansion_calculator = VectorExpansion(hypers, self.all_species, device=device)
+        self.vector_expansion_calculator = VectorExpansion(hypers, self.all_species,
+                device=device, dtype=dtype)
 
         if "alchemical" in self.hypers:
             self.is_alchemical = True
@@ -261,7 +264,9 @@ class VectorExpansion(torch.nn.Module):
 
     """
 
-    def __init__(self, hypers: Dict, all_species, device: str = "cpu") -> None:
+    def __init__(self, hypers: Dict, all_species,
+            device: Optional[torch.device] = None,
+            dtype: Optional[torch.device] = None) -> None:
         super().__init__()
 
         self.hypers = hypers
@@ -277,7 +282,8 @@ class VectorExpansion(torch.nn.Module):
         else:
             self.n_pseudo_species = 0  # dummy for torchscript
             self.is_alchemical = False
-        self.radial_basis_calculator = RadialBasis(hypers_radial_basis, all_species, device=device)
+        self.radial_basis_calculator = RadialBasis(hypers_radial_basis, all_species,
+                device=device, dtype=dtype)
         self.l_max = self.radial_basis_calculator.l_max
         self.spherical_harmonics_calculator = sphericart.torch.SphericalHarmonics(self.l_max, normalized=True)
         self.spherical_harmonics_split_list = [(2*l+1) for l in range(self.l_max+1)]

--- a/torch_spex/splines.py
+++ b/torch_spex/splines.py
@@ -1,5 +1,6 @@
 import numpy as np
 import torch
+from typing import Optional
 
 
 def generate_splines(
@@ -8,7 +9,8 @@ def generate_splines(
     max_index,
     cutoff_radius,
     requested_accuracy=1e-8,
-    device="cpu"
+    device: Optional[torch.device]=None,
+    dtype: Optional[torch.dtype]=None
 ):
     """Spline generator for tabulated radial integrals.
 
@@ -53,9 +55,9 @@ def generate_splines(
         value_evaluator_2D,
         derivative_evaluator_2D,
         requested_accuracy,
-        device=device
+        device=device,
+        dtype=dtype
     )
-
     return dynamic_spliner
 
 
@@ -68,7 +70,8 @@ class DynamicSpliner(torch.nn.Module):
         values_fn,
         derivatives_fn,
         requested_accuracy,
-        device
+        device: Optional[torch.device]=None,
+        dtype: Optional[torch.dtype]=None,
     ) -> None:
         super().__init__()
 
@@ -132,9 +135,9 @@ class DynamicSpliner(torch.nn.Module):
             self.spline_values = concatenated_values[sort_indices]
             self.spline_derivatives = concatenated_derivatives[sort_indices]
 
-        self.spline_positions = self.spline_positions.to(device)
-        self.spline_values = self.spline_values.to(device)
-        self.spline_derivatives = self.spline_derivatives.to(device)
+        self.spline_positions = self.spline_positions.to(device=device, dtype=dtype)
+        self.spline_values = self.spline_values.to(device=device, dtype=dtype)
+        self.spline_derivatives = self.spline_derivatives.to(device=device, dtype=dtype)
 
     def compute(self, positions):
         x = positions


### PR DESCRIPTION
So we can set the type consistently everywhere.

In the forward path we can follow the philosophy, just adapt to the input dtype, but one wants to have control of the dtype for the initialization of modules